### PR TITLE
Use a primitive vector for building byte array

### DIFF
--- a/src/clj/puppetlabs/trapperkeeper/rpc/wire.clj
+++ b/src/clj/puppetlabs/trapperkeeper/rpc/wire.clj
@@ -6,7 +6,7 @@
 
 (defn input-stream-to-byte-array
   [^InputStream stream]
-  (let [byte-vector (loop [bv []]
+  (let [byte-vector (loop [bv (vector-of :int)]
                       (let [next-byte (.read stream)]
                         (if (= -1 next-byte)
                           bv


### PR DESCRIPTION
This is another simple performance optimization for this function. Normally I don't bother with primitive arrays, but since we're looping over every single character in the stream I think we should do whatever we can here.