### PR TITLE
Expose macros for creating RPC'd services and re-use HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Planned features:
 ```clojure
 (ns gnarlytimes.services
     (:require [puppetlabs.trapperkeeper.core :refer [defservice]]
-              [puppetlabs.trapperkeeper.rpc.core :refer [call-remote-svc-fn]]))
+              [puppetlabs.trapperkeeper.rpc.core :refer [defremoteservice]]))
 
 ;; (note: TK best practices are eschewed for the sake of brevity)
 
@@ -50,11 +50,10 @@ Planned features:
     (divide [this x y] (/ x y)))
 
 ;; A proxied implementation of MathService for use via RPC
-(defservice remote-math-service
+(defremoteservice remote-math-service
     MathService
-    [[:ConfigService get-in-config]]
-    (add [this x y] (call-remote-svc-fn (get-in-config [:rpc]) :MathService :add x y))
-    (divide [this x y] (call-remote-svc-fn (get-in-config [:rpc]) :MathService :divide x y)))
+    (add [this x y])
+    (divide [this x y]))
 ```
 
 Given the following config:

--- a/dev-resources/logback-test.xml
+++ b/dev-resources/logback-test.xml
@@ -1,22 +1,9 @@
 <configuration scan="true">
-    <appender name="DSFILE" class="ch.qos.logback.core.FileAppender">
-        <file>apacheds-test.log</file>
-        <append>false</append>
-        <encoder>
-            <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>
         </encoder>
     </appender>
-
-    <!--<logger name="log4j.logger.org.eclipse.jetty.server" level="warn"/>-->
-    <logger name="org.apache.directory.server" additivity="false">
-        <appender-ref ref="DSFILE" />
-    </logger>
 
     <root level="warn">
         <appender-ref ref="STDOUT" />

--- a/dev-resources/puppetlabs/trapperkeeper/rpc/testutils/dummy_services/proxied.clj
+++ b/dev-resources/puppetlabs/trapperkeeper/rpc/testutils/dummy_services/proxied.clj
@@ -1,10 +1,8 @@
 (ns puppetlabs.trapperkeeper.rpc.testutils.dummy-services.proxied
   (:require [puppetlabs.trapperkeeper.rpc.testutils.dummy-services :refer [RPCTestService]]
-            [puppetlabs.trapperkeeper.rpc.core :refer [call-remote-svc-fn]]
-            [puppetlabs.trapperkeeper.services :refer [defservice]]))
+            [puppetlabs.trapperkeeper.rpc.core :refer [defremoteservice]]))
 
-(defservice rpc-test-service-proxied
+(defremoteservice rpc-test-service-proxied
   RPCTestService
-  [[:ConfigService get-in-config]]
-  (add [this x y] (call-remote-svc-fn (get-in-config [:rpc]) :RPCTestService :add x y))
-  (fun-divide [this x] (call-remote-svc-fn (get-in-config [:rpc]) :RPCTestService :fun-divide x)))
+  (add [this x y])
+  (fun-divide [this x]))

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def ks-version "1.0.0")
 (def tk-version "1.0.1")
 
-(defproject puppetlabs/trapperkeeper-rpc "0.1.2-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-rpc "1.0.0-SNAPSHOT"
   :description "RPC server/client library for Trapperkeeper services"
   :url "https://github.com/puppetlabs/trapperkeeper-rpc"
   :pedantic? :abort


### PR DESCRIPTION
This commit adds helpful macros for automatically creating RPC'd TK services.

the underlying call-remote-svc-fn is still available / exposed for more complex
services but these macros should be the standard for making RPC'd services.

Additionally, a memoized function now wraps http.client.sync/create-client
based on rpc settings and svc id, meaning that http clients are reused per
service.